### PR TITLE
Re-arrange resume functionality for recent import changes.

### DIFF
--- a/src/lsdb_macauff/import_pipeline/map_reduce.py
+++ b/src/lsdb_macauff/import_pipeline/map_reduce.py
@@ -1,3 +1,5 @@
+import pickle
+
 import healpy as hp
 import numpy as np
 import pyarrow as pa
@@ -6,7 +8,7 @@ from hipscat.io import file_io, paths
 from hipscat.pixel_math.healpix_pixel import HealpixPixel
 from hipscat.pixel_math.healpix_pixel_function import get_pixel_argsort
 from hipscat_import.catalog.map_reduce import _iterate_input_file
-from hipscat_import.pipeline_resume_plan import get_pixel_cache_directory
+from hipscat_import.pipeline_resume_plan import get_pixel_cache_directory, print_task_failure
 
 from lsdb_macauff.import_pipeline.resume_plan import MacauffResumePlan
 
@@ -15,12 +17,12 @@ from lsdb_macauff.import_pipeline.resume_plan import MacauffResumePlan
 
 def split_associations(
     input_file,
-    file_reader,
+    pickled_reader_file,
     splitting_key,
     highest_left_order,
     highest_right_order,
-    left_alignment,
-    right_alignment,
+    left_alignment_file,
+    right_alignment_file,
     left_ra_column,
     left_dec_column,
     right_ra_column,
@@ -34,74 +36,92 @@ def split_associations(
         ValueError: if the `ra_column` or `dec_column` cannot be found in the input file.
         FileNotFoundError: if the file does not exist, or is a directory
     """
-    for chunk_number, data, mapped_left_pixels in _iterate_input_file(
-        input_file, file_reader, highest_left_order, left_ra_column, left_dec_column, False
-    ):
-        aligned_left_pixels = left_alignment[mapped_left_pixels]
-        unique_pixels, unique_inverse = np.unique(aligned_left_pixels, return_inverse=True)
+    try:
+        with open(left_alignment_file, "rb") as pickle_file:
+            left_alignment = pickle.load(pickle_file)
+        with open(right_alignment_file, "rb") as pickle_file:
+            right_alignment = pickle.load(pickle_file)
 
-        mapped_right_pixels = hp.ang2pix(
-            2**highest_right_order,
-            data[right_ra_column].values,
-            data[right_dec_column].values,
-            lonlat=True,
-            nest=True,
-        )
-        aligned_right_pixels = right_alignment[mapped_right_pixels]
+        for chunk_number, data, mapped_left_pixels in _iterate_input_file(
+            input_file, pickled_reader_file, highest_left_order, left_ra_column, left_dec_column, False
+        ):
+            aligned_left_pixels = left_alignment[mapped_left_pixels]
+            unique_pixels, unique_inverse = np.unique(aligned_left_pixels, return_inverse=True)
 
-        data["Norder"] = [pix.order for pix in aligned_left_pixels]
-        data["Dir"] = [pix.dir for pix in aligned_left_pixels]
-        data["Npix"] = [pix.pixel for pix in aligned_left_pixels]
-
-        data["join_Norder"] = [pix.order for pix in aligned_right_pixels]
-        data["join_Dir"] = [pix.dir for pix in aligned_right_pixels]
-        data["join_Npix"] = [pix.pixel for pix in aligned_right_pixels]
-
-        for unique_index, pixel in enumerate(unique_pixels):
-            mapped_indexes = np.where(unique_inverse == unique_index)
-            data_indexes = data.index[mapped_indexes[0].tolist()]
-
-            filtered_data = data.filter(items=data_indexes, axis=0)
-
-            pixel_dir = get_pixel_cache_directory(tmp_path, pixel)
-            file_io.make_directory(pixel_dir, exist_ok=True)
-            output_file = file_io.append_paths_to_pointer(
-                pixel_dir, f"shard_{splitting_key}_{chunk_number}.parquet"
+            mapped_right_pixels = hp.ang2pix(
+                2**highest_right_order,
+                data[right_ra_column].values,
+                data[right_dec_column].values,
+                lonlat=True,
+                nest=True,
             )
-            filtered_data.to_parquet(output_file, index=False)
-        del data, filtered_data, data_indexes
+            aligned_right_pixels = right_alignment[mapped_right_pixels]
 
-    MacauffResumePlan.splitting_key_done(tmp_path=tmp_path, splitting_key=splitting_key)
+            data["Norder"] = [pix.order for pix in aligned_left_pixels]
+            data["Dir"] = [pix.dir for pix in aligned_left_pixels]
+            data["Npix"] = [pix.pixel for pix in aligned_left_pixels]
+
+            data["join_Norder"] = [pix.order for pix in aligned_right_pixels]
+            data["join_Dir"] = [pix.dir for pix in aligned_right_pixels]
+            data["join_Npix"] = [pix.pixel for pix in aligned_right_pixels]
+
+            for unique_index, pixel in enumerate(unique_pixels):
+                mapped_indexes = np.where(unique_inverse == unique_index)
+                data_indexes = data.index[mapped_indexes[0].tolist()]
+
+                filtered_data = data.filter(items=data_indexes, axis=0)
+
+                pixel_dir = get_pixel_cache_directory(tmp_path, pixel)
+                file_io.make_directory(pixel_dir, exist_ok=True)
+                output_file = file_io.append_paths_to_pointer(
+                    pixel_dir, f"shard_{splitting_key}_{chunk_number}.parquet"
+                )
+                filtered_data.to_parquet(output_file, index=False)
+            del data, filtered_data, data_indexes
+
+        MacauffResumePlan.splitting_key_done(tmp_path=tmp_path, splitting_key=splitting_key)
+    except Exception as exception:  # pylint: disable=broad-exception-caught
+        print_task_failure(f"Failed SPLITTING stage with file {input_file}", exception)
+        raise exception
 
 
 def reduce_associations(left_pixel, tmp_path, catalog_path, reduce_key):
     """For all points determined to be in the target left_pixel, map them to the appropriate right_pixel
     and aggregate into a single parquet file."""
-    inputs = get_pixel_cache_directory(tmp_path, left_pixel)
+    try:
+        inputs = get_pixel_cache_directory(tmp_path, left_pixel)
 
-    if not file_io.directory_has_contents(inputs):
-        MacauffResumePlan.reducing_key_done(
-            tmp_path=tmp_path, reducing_key=f"{left_pixel.order}_{left_pixel.pixel}"
+        if not file_io.directory_has_contents(inputs):
+            MacauffResumePlan.reducing_key_done(
+                tmp_path=tmp_path, reducing_key=f"{left_pixel.order}_{left_pixel.pixel}"
+            )
+            print(f"Warning: no input data for pixel {left_pixel}")
+            return
+        destination_dir = paths.pixel_directory(catalog_path, left_pixel.order, left_pixel.pixel)
+        file_io.make_directory(destination_dir, exist_ok=True)
+
+        destination_file = paths.pixel_catalog_file(catalog_path, left_pixel.order, left_pixel.pixel)
+
+        merged_table = pq.read_table(inputs)
+        dataframe = merged_table.to_pandas().reset_index()
+
+        ## One row group per join_Norder/join_Npix
+
+        join_pixel_frames = dataframe.groupby(["join_Norder", "join_Npix"], group_keys=True)
+        join_pixels = [HealpixPixel(pixel[0], pixel[1]) for pixel, _ in join_pixel_frames]
+        pixel_argsort = get_pixel_argsort(join_pixels)
+        with pq.ParquetWriter(destination_file, merged_table.schema) as writer:
+            for pixel_index in pixel_argsort:
+                join_pixel = join_pixels[pixel_index]
+                join_pixel_frame = join_pixel_frames.get_group(
+                    (join_pixel.order, join_pixel.pixel)
+                ).reset_index()
+                writer.write_table(pa.Table.from_pandas(join_pixel_frame, schema=merged_table.schema))
+
+        MacauffResumePlan.reducing_key_done(tmp_path=tmp_path, reducing_key=reduce_key)
+    except Exception as exception:  # pylint: disable=broad-exception-caught
+        print_task_failure(
+            f"Failed REDUCING stage for shard: {left_pixel.order} {left_pixel.pixel}",
+            exception,
         )
-        print(f"Warning: no input data for pixel {left_pixel}")
-        return
-    destination_dir = paths.pixel_directory(catalog_path, left_pixel.order, left_pixel.pixel)
-    file_io.make_directory(destination_dir, exist_ok=True)
-
-    destination_file = paths.pixel_catalog_file(catalog_path, left_pixel.order, left_pixel.pixel)
-
-    merged_table = pq.read_table(inputs)
-    dataframe = merged_table.to_pandas().reset_index()
-
-    ## One row group per join_Norder/join_Npix
-
-    join_pixel_frames = dataframe.groupby(["join_Norder", "join_Npix"], group_keys=True)
-    join_pixels = [HealpixPixel(pixel[0], pixel[1]) for pixel, _ in join_pixel_frames]
-    pixel_argsort = get_pixel_argsort(join_pixels)
-    with pq.ParquetWriter(destination_file, merged_table.schema) as writer:
-        for pixel_index in pixel_argsort:
-            join_pixel = join_pixels[pixel_index]
-            join_pixel_frame = join_pixel_frames.get_group((join_pixel.order, join_pixel.pixel)).reset_index()
-            writer.write_table(pa.Table.from_pandas(join_pixel_frame, schema=merged_table.schema))
-
-    MacauffResumePlan.reducing_key_done(tmp_path=tmp_path, reducing_key=reduce_key)
+        raise exception

--- a/src/lsdb_macauff/import_pipeline/resume_plan.py
+++ b/src/lsdb_macauff/import_pipeline/resume_plan.py
@@ -2,16 +2,19 @@
 
 from __future__ import annotations
 
+import pickle
 from dataclasses import dataclass, field
-from typing import List, Tuple
+from typing import List
 
+import healpy as hp
+import numpy as np
+from hipscat.catalog import Catalog
 from hipscat.io import FilePointer, file_io
 from hipscat.pixel_math.healpix_pixel import HealpixPixel
 from hipscat_import.pipeline_resume_plan import PipelineResumePlan
+from tqdm.auto import tqdm
 
 from lsdb_macauff.import_pipeline.arguments import MacauffArguments
-
-# pylint: disable=duplicate-code
 
 
 @dataclass
@@ -20,51 +23,99 @@ class MacauffResumePlan(PipelineResumePlan):
 
     input_paths: List[FilePointer] = field(default_factory=list)
     """resolved list of all files that will be used in the importer"""
-    split_keys: List[Tuple[str, str]] = field(default_factory=list)
-    """set of files (and job keys) that have yet to be split"""
-    reduce_keys: List[Tuple[HealpixPixel, str]] = field(default_factory=list)
-    """set of left side catalog pixels (and job keys) that have yet to be reduced/combined"""
+    left_pixels: List[HealpixPixel] = field(default_factory=list)
+    highest_left_order: int = 0
+    highest_right_order: int = 0
+    left_alignment_file: str = None
+    right_alignment_file: str = None
 
     SPLITTING_STAGE = "splitting"
     REDUCING_STAGE = "reducing"
+    LEFT_ALIGNMENT_FILE = "left_alignment.pickle"
+    RIGHT_ALIGNMENT_FILE = "right_alignment.pickle"
 
-    def __init__(self, args: MacauffArguments, left_pixels):
+    def __init__(self, args: MacauffArguments):
         if not args.tmp_path:  # pragma: no cover (not reachable, but required for mypy)
             raise ValueError("tmp_path is required")
         super().__init__(resume=args.resume, progress_bar=args.progress_bar, tmp_path=args.tmp_path)
         self.input_paths = args.input_paths
-        self.gather_plan(left_pixels)
+        self.gather_plan(args)
 
-    def gather_plan(self, left_pixels):
+    def gather_plan(self, args):
         """Initialize the plan."""
         ## Make sure it's safe to use existing resume state.
         super().safe_to_resume()
 
-        ## Validate existing resume state.
-        ## - if a later stage is complete, the earlier stages should be complete too.
-        splitting_done = self.is_splitting_done()
-        reducing_done = self.is_reducing_done()
+        with tqdm(total=5, desc="Planning", disable=not args.progress_bar) as step_progress:
+            ## Validate existing resume state.
+            ## - if a later stage is complete, the earlier stages should be complete too.
+            splitting_done = self.is_splitting_done()
+            reducing_done = self.is_reducing_done()
 
-        if reducing_done and not splitting_done:
-            raise ValueError("splitting must be complete before reducing")
+            if reducing_done and not splitting_done:
+                raise ValueError("splitting must be complete before reducing")
 
-        ## Validate that we're operating on the same file set as the previous instance.
-        self.input_paths = self.check_original_input_paths(self.input_paths)
+            ## Validate that we're operating on the same file set as the previous instance.
+            self.input_paths = self.check_original_input_paths(self.input_paths)
 
-        ## Gather keys for execution.
-        if not splitting_done:
-            self.split_keys = self.get_remaining_split_keys()
-        if not reducing_done:
-            self.reduce_keys = self.get_reduce_keys(left_pixels)
-        ## Go ahead and create our directories for storing resume files.
-        file_io.make_directory(
-            file_io.append_paths_to_pointer(self.tmp_path, self.SPLITTING_STAGE),
-            exist_ok=True,
-        )
-        file_io.make_directory(
-            file_io.append_paths_to_pointer(self.tmp_path, self.REDUCING_STAGE),
-            exist_ok=True,
-        )
+            left_catalog = Catalog.read_from_hipscat(args.left_catalog_dir)
+            step_progress.update(1)
+            right_catalog = Catalog.read_from_hipscat(args.right_catalog_dir)
+            step_progress.update(1)
+            self.highest_left_order = left_catalog.partition_info.get_highest_order()
+            self.highest_right_order = right_catalog.partition_info.get_highest_order()
+
+            self.left_pixels = left_catalog.partition_info.get_healpix_pixels()
+            right_pixels = right_catalog.partition_info.get_healpix_pixels()
+
+            ## Gather keys for execution.
+            if not splitting_done:
+                self.left_alignment_file = file_io.append_paths_to_pointer(
+                    self.tmp_path, self.LEFT_ALIGNMENT_FILE
+                )
+                self.right_alignment_file = file_io.append_paths_to_pointer(
+                    self.tmp_path, self.RIGHT_ALIGNMENT_FILE
+                )
+                if not file_io.does_file_or_directory_exist(
+                    self.left_alignment_file
+                ) or not file_io.does_file_or_directory_exist(self.right_alignment_file):
+                    regenerated_left_alignment = np.full(hp.order2npix(self.highest_left_order), None)
+                    for pixel in self.left_pixels:
+                        explosion_factor = 4 ** (self.highest_left_order - pixel.order)
+                        exploded_pixels = np.arange(
+                            pixel.pixel * explosion_factor,
+                            (pixel.pixel + 1) * explosion_factor,
+                        )
+                        regenerated_left_alignment[exploded_pixels] = pixel
+                    regenerated_right_alignment = np.full(hp.order2npix(self.highest_right_order), None)
+                    for pixel in right_pixels:
+                        explosion_factor = 4 ** (self.highest_right_order - pixel.order)
+                        exploded_pixels = np.arange(
+                            pixel.pixel * explosion_factor,
+                            (pixel.pixel + 1) * explosion_factor,
+                        )
+                        regenerated_right_alignment[exploded_pixels] = pixel
+
+                    with open(self.left_alignment_file, "wb") as pickle_file:
+                        pickle.dump(regenerated_left_alignment, pickle_file)
+
+                    with open(self.right_alignment_file, "wb") as pickle_file:
+                        pickle.dump(regenerated_right_alignment, pickle_file)
+
+            step_progress.update(1)
+
+            if not reducing_done:
+                self.reduce_keys = self.get_reduce_keys()
+            ## Go ahead and create our directories for storing resume files.
+            file_io.make_directory(
+                file_io.append_paths_to_pointer(self.tmp_path, self.SPLITTING_STAGE),
+                exist_ok=True,
+            )
+            file_io.make_directory(
+                file_io.append_paths_to_pointer(self.tmp_path, self.REDUCING_STAGE),
+                exist_ok=True,
+            )
+            step_progress.update(1)
 
     def get_remaining_split_keys(self):
         """Gather remaining keys, dropping successful split tasks from done file names.
@@ -111,7 +162,7 @@ class MacauffResumePlan(PipelineResumePlan):
         """Are there files left to split?"""
         return self.done_file_exists(self.SPLITTING_STAGE)
 
-    def get_reduce_keys(self, left_pixels):
+    def get_reduce_keys(self):
         """Fetch a Tuple for each partition to reduce.
 
         Tuple contains:
@@ -123,7 +174,7 @@ class MacauffResumePlan(PipelineResumePlan):
         reduced_keys = set(self.read_done_keys(self.REDUCING_STAGE))
         reduce_items = [
             (hp_pixel, f"{hp_pixel.order}_{hp_pixel.pixel}")
-            for hp_pixel in left_pixels
+            for hp_pixel in self.left_pixels
             if f"{hp_pixel.order}_{hp_pixel.pixel}" not in reduced_keys
         ]
         return reduce_items
@@ -132,10 +183,10 @@ class MacauffResumePlan(PipelineResumePlan):
         """Are there partitions left to reduce?"""
         return self.done_file_exists(self.REDUCING_STAGE)
 
-    def wait_for_reducing(self, futures, left_pixels):
+    def wait_for_reducing(self, futures):
         """Wait for reducing futures to complete."""
         self.wait_for_futures(futures, self.REDUCING_STAGE)
-        remaining_reduce_items = self.get_reduce_keys(left_pixels)
+        remaining_reduce_items = self.get_reduce_keys()
         if len(remaining_reduce_items) > 0:
             raise RuntimeError(f"{len(remaining_reduce_items)} reduce stages did not complete successfully.")
         self.touch_stage_done_file(self.REDUCING_STAGE)

--- a/src/lsdb_macauff/import_pipeline/resume_plan.py
+++ b/src/lsdb_macauff/import_pipeline/resume_plan.py
@@ -46,7 +46,7 @@ class MacauffResumePlan(PipelineResumePlan):
         ## Make sure it's safe to use existing resume state.
         super().safe_to_resume()
 
-        with tqdm(total=5, desc="Planning", disable=not args.progress_bar) as step_progress:
+        with tqdm(total=4, desc="Planning", disable=not args.progress_bar) as step_progress:
             ## Validate existing resume state.
             ## - if a later stage is complete, the earlier stages should be complete too.
             splitting_done = self.is_splitting_done()

--- a/src/lsdb_macauff/import_pipeline/run_import.py
+++ b/src/lsdb_macauff/import_pipeline/run_import.py
@@ -1,6 +1,6 @@
-import healpy as hp
-import numpy as np
-from hipscat.catalog import Catalog
+import os
+import pickle
+
 from hipscat.catalog.association_catalog.partition_join_info import PartitionJoinInfo
 from hipscat.io import file_io, parquet_metadata, paths, write_metadata
 from tqdm.auto import tqdm
@@ -8,71 +8,6 @@ from tqdm.auto import tqdm
 from lsdb_macauff.import_pipeline.arguments import MacauffArguments
 from lsdb_macauff.import_pipeline.map_reduce import reduce_associations, split_associations
 from lsdb_macauff.import_pipeline.resume_plan import MacauffResumePlan
-
-# pylint: disable=unused-argument
-
-
-def split(
-    args,
-    highest_left_order,
-    highest_right_order,
-    left_alignment,
-    right_alignment,
-    resume_plan,
-    client,
-):
-    """Split association rows by their aligned left pixel."""
-
-    if resume_plan.is_splitting_done():
-        return
-
-    reader_future = client.scatter(args.file_reader)
-    left_alignment_future = client.scatter(left_alignment)
-    right_alignment_future = client.scatter(right_alignment)
-    futures = []
-    for key, file_path in resume_plan.split_keys:
-        futures.append(
-            client.submit(
-                split_associations,
-                input_file=file_path,
-                file_reader=reader_future,
-                splitting_key=key,
-                highest_left_order=highest_left_order,
-                highest_right_order=highest_right_order,
-                left_alignment=left_alignment_future,
-                right_alignment=right_alignment_future,
-                left_ra_column=args.left_ra_column,
-                left_dec_column=args.left_dec_column,
-                right_ra_column=args.right_ra_column,
-                right_dec_column=args.right_dec_column,
-                tmp_path=args.tmp_path,
-            )
-        )
-    resume_plan.wait_for_splitting(futures)
-
-
-def reduce(args, left_pixels, resume_plan, client):
-    """Reduce left pixel files into a single parquet file per."""
-
-    if resume_plan.is_reducing_done():
-        return
-
-    futures = []
-    for (
-        left_pixel,
-        pixel_key,
-    ) in resume_plan.reduce_keys:
-        futures.append(
-            client.submit(
-                reduce_associations,
-                left_pixel=left_pixel,
-                tmp_path=args.tmp_path,
-                catalog_path=args.catalog_path,
-                reduce_key=pixel_key,
-            )
-        )
-
-    resume_plan.wait_for_reducing(futures, left_pixels)
 
 
 def run(args, client):
@@ -82,52 +17,50 @@ def run(args, client):
     if not isinstance(args, MacauffArguments):
         raise TypeError("args must be type MacauffArguments")
 
-    ## Lump all of the catalog reading stuff together under a single block,
-    ## since it can take a while to load large catalogs and some feedback is nice.
-    with tqdm(total=5, desc="Planning", disable=not args.progress_bar) as step_progress:
-        left_catalog = Catalog.read_from_hipscat(args.left_catalog_dir)
-        step_progress.update(1)
-        right_catalog = Catalog.read_from_hipscat(args.right_catalog_dir)
-        step_progress.update(1)
-        highest_left_order = left_catalog.partition_info.get_highest_order()
-        highest_right_order = right_catalog.partition_info.get_highest_order()
+    resume_plan = MacauffResumePlan(args)
 
-        left_pixels = left_catalog.partition_info.get_healpix_pixels()
-        right_pixels = right_catalog.partition_info.get_healpix_pixels()
-
-        regenerated_left_alignment = np.full(hp.order2npix(highest_left_order), None)
-        for pixel in left_pixels:
-            explosion_factor = 4 ** (highest_left_order - pixel.order)
-            exploded_pixels = np.arange(
-                pixel.pixel * explosion_factor,
-                (pixel.pixel + 1) * explosion_factor,
+    if not resume_plan.is_splitting_done():
+        pickled_reader_file = os.path.join(resume_plan.tmp_path, "reader.pickle")
+        with open(pickled_reader_file, "wb") as pickle_file:
+            pickle.dump(args.file_reader, pickle_file)
+        futures = []
+        for key, file_path in resume_plan.get_remaining_split_keys():
+            futures.append(
+                client.submit(
+                    split_associations,
+                    input_file=file_path,
+                    pickled_reader_file=pickled_reader_file,
+                    splitting_key=key,
+                    highest_left_order=resume_plan.highest_left_order,
+                    highest_right_order=resume_plan.highest_right_order,
+                    left_alignment_file=resume_plan.left_alignment_file,
+                    right_alignment_file=resume_plan.right_alignment_file,
+                    left_ra_column=args.left_ra_column,
+                    left_dec_column=args.left_dec_column,
+                    right_ra_column=args.right_ra_column,
+                    right_dec_column=args.right_dec_column,
+                    tmp_path=args.tmp_path,
+                )
             )
-            regenerated_left_alignment[exploded_pixels] = pixel
-        step_progress.update(1)
+        resume_plan.wait_for_splitting(futures)
 
-        regenerated_right_alignment = np.full(hp.order2npix(highest_right_order), None)
-        for pixel in right_pixels:
-            explosion_factor = 4 ** (highest_right_order - pixel.order)
-            exploded_pixels = np.arange(
-                pixel.pixel * explosion_factor,
-                (pixel.pixel + 1) * explosion_factor,
+    if not resume_plan.is_reducing_done():
+        futures = []
+        for (
+            left_pixel,
+            pixel_key,
+        ) in resume_plan.get_reduce_keys():
+            futures.append(
+                client.submit(
+                    reduce_associations,
+                    left_pixel=left_pixel,
+                    tmp_path=args.tmp_path,
+                    catalog_path=args.catalog_path,
+                    reduce_key=pixel_key,
+                )
             )
-            regenerated_right_alignment[exploded_pixels] = pixel
-        step_progress.update(1)
 
-        resume_plan = MacauffResumePlan(args, left_pixels)
-        step_progress.update(1)
-
-    split(
-        args,
-        highest_left_order=highest_left_order,
-        highest_right_order=highest_right_order,
-        left_alignment=regenerated_left_alignment,
-        right_alignment=regenerated_right_alignment,
-        resume_plan=resume_plan,
-        client=client,
-    )
-    reduce(args, left_pixels, resume_plan, client)
+        resume_plan.wait_for_reducing(futures)
 
     # All done - write out the metadata
     with tqdm(total=4, desc="Finishing", disable=not args.progress_bar) as step_progress:


### PR DESCRIPTION
We've made a few recent change in the upstream hipscat-import catalog import pipeline that have broken the macauff import, but also some that are just handy and would be nice to see in this pipeline as well.

- print any task failures back to the dask controller job logs, for easier debugging
- pickle large objects instead of using `dask.scatter`, as this has known limitations in some slurm/HSC enviromnents
- consolidates logic for alignment generation and task production into the resume plan

See related changes: 
- https://github.com/astronomy-commons/hipscat-import/pull/328
- https://github.com/astronomy-commons/hipscat-import/pull/318